### PR TITLE
32 bug fix clang tidy warnings about compiler flags

### DIFF
--- a/.github/workflows/testing-and-static-analysis.yml
+++ b/.github/workflows/testing-and-static-analysis.yml
@@ -121,5 +121,5 @@ jobs:
           $DOCKER_RUN ${{ env.IMAGE_TAG }} bash -lc '
             set -euo pipefail
             find Project -type f \( -name "*.c" -o -name "*.cpp" \) -print0 \
-              | xargs -0 -r clang-tidy -p build-host -extra-arg=-Wduplicated-branches -extra-arg=-Wduplicated-cond -extra-arg=-Wlogical-op -extra-arg=-Wrestrict
+              | xargs -0 -r clang-tidy -p build-host -extra-arg=-Wno-unknown-warning-option
             '


### PR DESCRIPTION
It was as simple as adding a flag to clang-tidy `-extra-arg=-Wno-unknown-warning-option` to ignore the compile flags of the project